### PR TITLE
Return 1 byte length for zero len values when determining spaceForLength

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/philpearl/stringbank
+module github.com/ou05020/stringbank
 
 go 1.12
 

--- a/stringbank.go
+++ b/stringbank.go
@@ -74,6 +74,9 @@ func (s *Stringbank) reserve(l int) (index int, data []byte) {
 }
 
 func spaceForLength(len int) int {
+	if len == 0 {
+		return 1
+	}
 	// 7 bits => 1 byte
 	// 8 bits => 2 byte
 	// 1


### PR DESCRIPTION
bits.Len returns 0 when len == 0. That results in a zero result returned by `spaceForLength` due to integer division (6/7). The writeLength function is then called using 1 byte to write the zero length value leading to a discrepancy between reserved (0) and written (1) number of bytes.

This causes incorrect values to be returned for empty strings in Stringbank.Get.